### PR TITLE
updated basic and sectionheader tests to python script (experimental)

### DIFF
--- a/tests/Basic.txt
+++ b/tests/Basic.txt
@@ -7,7 +7,7 @@ Library           Collections
 
 *** Test Cases ***
 000 Environment
-    ${result} =    Run Process    ../tools/gennlm.sh 001.docx ./000    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py 001.docx -o ./000    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     Should Not Contain    ${result.stderr}    cannot find or open
@@ -15,7 +15,7 @@ Library           Collections
     [Teardown]    Remove Directory    000    recursive=True
 
 001 Basic paragraph
-    ${result} =    Run Process    ../tools/gennlm.sh 001.docx ./001    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py 001.docx -o ./001    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./001/001.xml
@@ -24,7 +24,7 @@ Library           Collections
     [Teardown]    Remove Directory    001    recursive=True
 
 002 Basic paragraph with italics
-    ${result} =    Run Process    ../tools/gennlm.sh 002.docx ./002    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py 002.docx -o ./002    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./002/002.xml
@@ -33,7 +33,7 @@ Library           Collections
     [Teardown]    Remove Directory    002    recursive=True
 
 003 Basic paragraph with bold
-    ${result} =    Run Process    ../tools/gennlm.sh 003.docx ./003    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py 003.docx -o ./003    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./003/003.xml
@@ -43,7 +43,7 @@ Library           Collections
 
 004 Metadata merge
     [Tags]    metadata
-    ${result} =    Run Process    ../tools/gennlm.sh 002.docx ./004    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py 002.docx -o ./004    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./004/002.xml
@@ -79,7 +79,7 @@ Library           Collections
 
 005 Title, non-title, title (from bolded text)
     [Tags]    formatting    bold    title
-    ${result} =    Run Process    ../tools/gennlm.sh 005.docx ./005    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py 005.docx -o ./005    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./005/005.xml

--- a/tests/sectionHeaders.txt
+++ b/tests/sectionHeaders.txt
@@ -6,9 +6,9 @@ Library           XML
 Library           Collections
 
 *** Test Cases ***
-501 Title, non-title, title
+501 Title, non-title, title-antiseptics-complex
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/antiseptics-complex.docx ./501    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/antiseptics-complex.docx -o ./501    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./501/001.xml
@@ -23,9 +23,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    501    recursive=True
 
-502 Title, non-title, title
+502 Title, non-title, title-china-asleep
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/china-asleep.docx ./502    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/china-asleep.docx -o ./502    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./502/001.xml
@@ -40,9 +40,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    502    recursive=True
 
-503 Title, non-title, title
+503 Title, non-title, title-eeg_comicsans
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/eeg_comicsans.docx ./503    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/eeg_comicsans.docx -o ./503    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./503/001.xml
@@ -57,9 +57,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    503    recursive=True
 
-504 Title, non-title, title
+504 Title, non-title, title-entrepreneurship-normal
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/entrepreneurship-normal.docx ./504    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/entrepreneurship-normal.docx -o ./504    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./504/001.xml
@@ -74,9 +74,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    504    recursive=True
 
-505 Title, non-title, title
+505 Title, non-title, title-equations+tables
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/equations+tables.docx ./505    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/equations+tables.docx -o ./505    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./505/001.xml
@@ -91,9 +91,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    505    recursive=True
 
-506 Title, non-title, title
+506 Title, non-title, title-laddering
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/laddering.docx ./506    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/laddering.docx -o ./506    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./506/001.xml
@@ -108,9 +108,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    506    recursive=True
 
-507 Title, non-title, title
+507 Title, non-title, title-leadership
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/leadership.docx ./507    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/leadership.docx -o ./507    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./507/001.xml
@@ -125,9 +125,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    507    recursive=True
 
-508 Title, non-title, title
+508 Title, non-title, title-neoliberalism
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/neoliberalism.docx ./508    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/neoliberalism.docx -o ./508    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./508/001.xml
@@ -142,9 +142,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    508    recursive=True
 
-509 Title, non-title, title
+509 Title, non-title, title-perception-monospace
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/perception-monospace.docx ./509    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/perception-monospace.docx -o ./509    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./509/001.xml
@@ -159,9 +159,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    509    recursive=True
 
-510 Title, non-title, title
+510 Title, non-title, title-racialprofiling-norefs
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/racialprofiling-norefs.docx ./510    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/racialprofiling-norefs.docx -o ./510    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./510/001.xml
@@ -176,9 +176,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    510    recursive=True
 
-511 Title, non-title, title
+511 Title, non-title, title-rating
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/rating.docx ./511    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/rating.docx -o ./511    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./511/001.xml
@@ -193,9 +193,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    511    recursive=True
 
-512 Title, non-title, title
+512 Title, non-title, title-science
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/science.docx ./512    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/science.docx -o ./512    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./512/001.xml
@@ -210,9 +210,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    512    recursive=True
 
-513 Title, non-title, title
+513 Title, non-title, title-snowball
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/snowball.docx ./513    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/snowball.docx -o ./513    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./513/001.xml
@@ -227,9 +227,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    513    recursive=True
 
-514 Title, non-title, title
+514 Title, non-title, title-sodium
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/sodium.docx ./514    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/sodium.docx -o ./514    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./514/001.xml
@@ -244,9 +244,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    514    recursive=True
 
-515 Title, non-title, title
+515 Title, non-title, title-systemsthinker
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/systemsthinker.docx ./515    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/systemsthinker.docx -o ./515    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./515/001.xml
@@ -261,9 +261,9 @@ Library           Collections
     Elements Should Match    ${secondsectiontitle}    <title>This should.</title>
     [Teardown]    Remove Directory    515    recursive=True
 
-516 Title, non-title, title
+516 Title, non-title, title-valuechain
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/valuechain.docx ./516    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/valuechain.docx -o ./516    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./516/001.xml
@@ -280,7 +280,7 @@ Library           Collections
 
 601 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/antiseptics-complex.docx ./601    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/antiseptics-complex.docx -o ./601    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./601/001.xml
@@ -294,7 +294,7 @@ Library           Collections
 
 602 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/china-asleep.docx ./602    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/china-asleep.docx -o ./602    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./602/001.xml
@@ -308,7 +308,7 @@ Library           Collections
 
 603 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/eeg_comicsans.docx ./603    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/eeg_comicsans.docx -o ./603    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./603/001.xml
@@ -322,7 +322,7 @@ Library           Collections
 
 604 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/entrepreneurship-normal.docx ./604    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/entrepreneurship-normal.docx -o ./604    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./604/001.xml
@@ -336,7 +336,7 @@ Library           Collections
 
 605 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/equations+tables.docx ./605    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/equations+tables.docx -o ./605    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./605/001.xml
@@ -350,7 +350,7 @@ Library           Collections
 
 606 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/laddering.docx ./606    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/laddering.docx -o ./606    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./606/001.xml
@@ -364,7 +364,7 @@ Library           Collections
 
 607 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/leadership.docx ./607    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/leadership.docx -o ./607    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./607/001.xml
@@ -378,7 +378,7 @@ Library           Collections
 
 608 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/neoliberalism.docx ./608    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/neoliberalism.docx -o ./608    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./608/001.xml
@@ -392,7 +392,7 @@ Library           Collections
 
 609 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/perception-monospace.docx ./609    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/perception-monospace.docx -o ./609    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./609/001.xml
@@ -406,7 +406,7 @@ Library           Collections
 
 610 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/racialprofiling-norefs.docx ./610    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/racialprofiling-norefs.docx -o ./610    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./610/001.xml
@@ -420,7 +420,7 @@ Library           Collections
 
 611 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/rating.docx ./611    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/rating.docx -o ./611    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./611/001.xml
@@ -434,7 +434,7 @@ Library           Collections
 
 612 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/science.docx ./612    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/science.docx -o ./612    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./612/001.xml
@@ -448,7 +448,7 @@ Library           Collections
 
 613 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/snowball.docx ./613    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/snowball.docx -o ./613    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./613/001.xml
@@ -462,7 +462,7 @@ Library           Collections
 
 614 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/sodium.docx ./614    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/sodium.docx -o ./614    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./614/001.xml
@@ -476,7 +476,7 @@ Library           Collections
 
 615 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/systemsthinker.docx ./615    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/systemsthinker.docx -o ./615    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./615/001.xml
@@ -490,7 +490,7 @@ Library           Collections
 
 616 Nested section title
     [Tags]    sectionheaders
-    ${result} =    Run Process    ../tools/gennlm.sh ../../corpus/valuechain.docx ./616    shell=True
+    ${result} =    Run Process    python ../bin/meTypeset.py ../../corpus/valuechain.docx -o ./616    shell=True
     Log    ${result.stdout}
     Log    ${result.stderr}
     ${xml}=    Parse XML    ./616/001.xml


### PR DESCRIPTION
simple change, still need to test more thoroughly to ensure nothing is going weird here; basically, two find-and-replaces performed on each set of tests:

../tools/gennlm.sh >> python ../bin/meTypeset.py

docx >> docx -o
