### PR TITLE
wmf handling routine now handles emf as well

### DIFF
--- a/bin/docxtotei.py
+++ b/bin/docxtotei.py
@@ -69,8 +69,8 @@ class DocxToTei(Debuggable):
             return False
 
         for image in image_filenames:
-            if re.match(r'.+?\.wmf', image) is not None:
-                image_name = re.sub(r'\.wmf', '', image)
+            if re.match(r'.+?\.(w|e)mf', image) is not None:
+                image_name = re.sub(r'\.(w|e)mf', '', image)
                 imagemagick_command = '{3}*DELIMITER*-d*DELIMITER*graphics*DELIMITER*-f*DELIMITER*png*DELIMITER*-o' \
                                       '*DELIMITER*{0}/{1}.png*DELIMITER*' \
                                       '{0}/{2}'.format(self.gv.output_media_path, image_name, image,

--- a/bin/teimanipulate.py
+++ b/bin/teimanipulate.py
@@ -807,7 +807,7 @@ class TeiManipulate(Manipulate):
 
         for image_link in tree.xpath('//tei:graphic', namespaces={'tei': 'http://www.tei-c.org/ns/1.0'}):
             count += 1
-            converted_image_link = re.sub(r'\.wmf', '.png', image_link.xpath('@url')[0])
+            converted_image_link = re.sub(r'\.(w|e)mf', '.png', image_link.xpath('@url')[0])
             image_link.attrib['url'] = converted_image_link
 
         self.save_tree(tree)


### PR DESCRIPTION
encountering some .emf images in the corpus as well -- these weren't converted by LibreOffice (the document in which I found them was "native" docx, as it came to me), so the Word user must've somehow embedded them that way. luckily they can be handled the exact same way as wmf.
