### PR TITLE
Fixes metadata option. Added missing attribute.

### DIFF
--- a/bin/meTypeset.py
+++ b/bin/meTypeset.py
@@ -94,7 +94,7 @@ class MeTypeset (Debuggable):
     def set_metadata_file(self):
         metadata_file_arg = self.settings.args['--metadata']
         if metadata_file_arg:
-            metadata_file = self.gv.settings.clean_path(self.gv.concat_path(self.settings.script_dir,
+            metadata_file = self.gv.settings.clean_path(self.gv.settings.concat_path(self.settings.script_dir,
                                                                             metadata_file_arg[0]))
         else:
             metadata_file = \


### PR DESCRIPTION
This is the error I was getting prior to the change:
 File "./meTypeset/bin/meTypeset.py", line 97, in set_metadata_file
    metadata_file = self.gv.settings.clean_path(self.gv.concat_path(self.settings.script_dir,
AttributeError: 'GV' object has no attribute 'concat_path'
