### PR TITLE
Reference identification

### DIFF
--- a/bin/nlmmanipulate.py
+++ b/bin/nlmmanipulate.py
@@ -370,7 +370,7 @@ class NlmManipulate(Manipulate):
 
                     text = self.get_stripped_text(p)
 
-                    year_test = re.compile('((18|19|20)\d{2}[a-z]?)|(n\.d\.)')
+                    year_test = re.compile('((1|2)\d{3}[a-z]?)|(n\.d\.)')
 
                     match = year_test.findall(text)
 
@@ -574,7 +574,7 @@ class NlmManipulate(Manipulate):
         for ref in tree.xpath('//back/ref-list/ref'):
             text = self.get_stripped_text(ref)
 
-            year_test = re.compile('((18|19|20)\d{2}[a-z]?)|(n\.d\.)')
+            year_test = re.compile('((1|2)\d{3}[a-z]?)|(n\.d\.)')
             match = year_test.findall(text)
 
             if not match and ref.getprevious() is not None:

--- a/bin/teimanipulate.py
+++ b/bin/teimanipulate.py
@@ -64,7 +64,7 @@ class TeiManipulate(Manipulate):
 
     def do_list_bibliography(self, xpath):
         found = False
-        year_test = re.compile('((18|19|20)\d{2}[a-z]?)|(n\.d\.)')
+        year_test =  re.compile('((1|2)\d{3}[a-z]?)|(n\.d\.)')
 
         for last_list in xpath:
             if last_list.tag.endswith('list'):
@@ -382,7 +382,7 @@ class TeiManipulate(Manipulate):
         last = None
 
         # pre-compile all needed regular expressions
-        year_test = re.compile('((18|19|20)\d{2}[a-z]?)|(n\.d\.)')
+        year_test =  re.compile('((1|2)\d{3}[a-z]?)|(n\.d\.)')
         blank_text = re.compile('XXXX')
         numeric_start_test = re.compile('^(?P<start>[\[{(]*?[\d\.]+[\]})]*?\s*?).+')
         break_index = 0


### PR DESCRIPTION
Reference identification changed from 1800 onwards to 1000 onwards.
Did not go much further backwards into years unless a thorough investigation  of page identification.