### PR TITLE
Fix DTD validation

### DIFF
--- a/metadata/metadata.xsl
+++ b/metadata/metadata.xsl
@@ -19,10 +19,12 @@
     <xsl:param name="metadataFile">metadata.xml</xsl:param>
     <xsl:param name="metadata" select="document(concat('file:////', $metadataFile))" />
     
-    <xsl:output method="xml" doctype-public="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.0 20120330//EN" doctype-system="JATS-journalpublishing1.dtd" xpath-default-namespace="" indent="yes"></xsl:output>
+    <xsl:output method="xml" doctype-public="-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.0 20120330//EN" doctype-system="https://jats.nlm.nih.gov/publishing/1.1/JATS-journalpublishing1.dtd" xpath-default-namespace="" indent="yes"></xsl:output>
        
     <xsl:template match="/">
         <xsl:element name="article">
+            <xsl:namespace name="mml" select="'http://www.w3.org/1998/Math/MathML'"/>
+            <xsl:namespace name="xlink" select="'http://www.w3.org/1999/xlink'"/>
             <xsl:apply-templates />
         </xsl:element>
     </xsl:template>


### PR DESCRIPTION
Hi @MartinPaulEve ,

In the metadata.xsl we had JATS-journalpublishing1.dtd  which should be a local file, although we do not have the schema in the generated folder.

NLM maintains  the DTD in a CDN manner, which can be automatically extracted for validation.

Another solution would be to copy the DTD from the runtime folder to each generated NLM folder, which may add extra storage, what I thought  users would not like. 

Other than, I added some common namespaces, xlink and mml, which are common in JATS files so that an automated validation is possible, even though some   files may not have mml.


Best wishes,
Dulip


