### PR TITLE
Fixed a regular expression bug in the docxtotei.py

### DIFF
--- a/bin/docxtotei.py
+++ b/bin/docxtotei.py
@@ -155,7 +155,7 @@ class DocxToTei(Debuggable):
             doc_prop = open(os.path.join(self.gv.docx_temp_folder_path, 'docProps', 'core.xml'), 'r+')
             contents = doc_prop.read()
 
-            contents = re.sub('\&\s', '\&amp;\s', contents)
+            contents = re.sub('\&(\s)', '\&amp;\1', contents)
 
             doc_prop.seek(0)
             doc_prop.write(contents)


### PR DESCRIPTION
Hi @MartinPaulEve ,

Before, running python 3.7, threw a KeyError at line 158 because of flawed regex.

```
Traceback (most recent call last):
  File "/meTypeset/venv3/lib/python3.7/sre_parse.py", line 1015, in parse_template
    this = chr(ESCAPES[this][1])
KeyError: '\\s'
```

It does not make sense to give ```\s``` in the substituting string. Instead, here a group of the found ```\s``` is used.